### PR TITLE
feat: add network and tag options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,16 @@ You'll need to wait for the machine and environment setup.
 
 This provides has the seguent options
 
-|    NAME           | REQUIRED |          DESCRIPTION           |         DEFAULT         |
-|----------------------------|----------|--------------------------------|----------------|
-|  DISK_IMAGE       | false    | The disk image to use.         | projects/cos-cloud/global/images/cos-101-17162-127-5 |
-|  DISK_SIZE        | false    | The disk size to use.          | 40                                                   |
-|  MACHINE_TYPE     | false    | The machine type to use.       | c2-standard-4                                        |
-|  PROJECT          | true     | The project id to use.         |                                                      |
-|  ZONE             | true     | The google cloud zone to       |                                                      |
-|                   |          | create the VM in. E.g.         |                                                      |
-|                   |          | europe-west1-d                 |                                                      |
+| NAME           | REQUIRED | DESCRIPTION                                                    | DEFAULT                                              |
+|----------------|----------|----------------------------------------------------------------|------------------------------------------------------|
+| DISK_IMAGE     | false    | The disk image to use.                                         | projects/cos-cloud/global/images/cos-101-17162-127-5 |
+| DISK_SIZE      | false    | The disk size to use.                                          | 40                                                   |
+| MACHINE_TYPE   | false    | The machine type to use.                                       | c2-standard-4                                        |
+| PROJECT        | true     | The project id to use.                                         |                                                      |
+| ZONE           | true     | The google cloud zone to create the VM in. E.g. europe-west1-d |                                                      |
+| NETWORK        | false    | The network id to use.                                         |                                                      |
+| SUBNETWORK     | false    | The subnetwork id to use.                                      |                                                      |
+| TAG            | false    | A tag to attach to the instance.                               | devpod                                               |
 
 Options can either be set in `env` or using for example:
 

--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -98,6 +98,13 @@ options:
       - us-west4-a
       - us-west4-b
       - us-west4-c
+  NETWORK:
+    description: The network id to use.
+  SUBNETWORK:
+    description: The subnetwork id to use.
+  TAG:
+    description: A tag to attach to the instance.
+    default: "devpod"
   DISK_SIZE:
     description: The disk size to use.
     default: "40"

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -11,6 +11,9 @@ type Options struct {
 
 	Project     string
 	Zone        string
+	Network     string
+	Subnetwork  string
+	Tag         string
 	DiskSize    string
 	DiskImage   string
 	MachineType string
@@ -54,6 +57,10 @@ func FromEnv(withMachine bool) (*Options, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	retOptions.Network = os.Getenv("NETWORK")
+	retOptions.Subnetwork = os.Getenv("SUBNETWORK")
+	retOptions.Tag = os.Getenv("TAG")
 
 	return retOptions, nil
 }


### PR DESCRIPTION
This PR adds options to configure a network/subnetwork and a network tag.
It will be helpful when a default network is not available in the target project, and with the tag, one can configure firewall rules in GCP