### PR TITLE
Add support for specifying service accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This provides has the seguent options
 | NETWORK        | false    | The network id to use.                                         |                                                      |
 | SUBNETWORK     | false    | The subnetwork id to use.                                      |                                                      |
 | TAG            | false    | A tag to attach to the instance.                               | devpod                                               |
+| SERVICE_ACCOUNT| false    | A service account to attach to instance
 
 Options can either be set in `env` or using for example:
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -73,7 +73,7 @@ func buildInstance(options *options.Options) (*computepb.Instance, error) {
 		return nil, err
 	}
 	serviceAccounts := []*computepb.ServiceAccount{}
-	if options.ServiceAccount != "none" {
+	if options.ServiceAccount != "" {
 
 		serviceAccounts = []*computepb.ServiceAccount{
 			{

--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -111,6 +111,9 @@ options:
   DISK_IMAGE:
     description: The disk image to use.
     default: projects/cos-cloud/global/images/cos-101-17162-127-5
+  SERVICE_ACCOUNT:
+    description: A service account to attach
+    default: "none"
   MACHINE_TYPE:
     description: The machine type to use.
     default: c2-standard-4

--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -113,7 +113,7 @@ options:
     default: projects/cos-cloud/global/images/cos-101-17162-127-5
   SERVICE_ACCOUNT:
     description: A service account to attach
-    default: "none"
+    default: ""
   MACHINE_TYPE:
     description: The machine type to use.
     default: c2-standard-4

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -58,11 +58,8 @@ func FromEnv(withMachine bool) (*Options, error) {
 	if err != nil {
 		return nil, err
 	}
-	retOptions.ServiceAccount, err = fromEnvOrError("SERVICE_ACCOUNT")
-	if err != nil {
-		return nil, err
-	}
 
+	retOptions.ServiceAccount = os.Getenv("SERVICE_ACCOUNT")
 	retOptions.Network = os.Getenv("NETWORK")
 	retOptions.Subnetwork = os.Getenv("SUBNETWORK")
 	retOptions.Tag = os.Getenv("TAG")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -9,14 +9,15 @@ type Options struct {
 	MachineID     string
 	MachineFolder string
 
-	Project     string
-	Zone        string
-	Network     string
-	Subnetwork  string
-	Tag         string
-	DiskSize    string
-	DiskImage   string
-	MachineType string
+	Project        string
+	Zone           string
+	Network        string
+	Subnetwork     string
+	Tag            string
+	DiskSize       string
+	DiskImage      string
+	MachineType    string
+	ServiceAccount string
 }
 
 func FromEnv(withMachine bool) (*Options, error) {
@@ -54,6 +55,10 @@ func FromEnv(withMachine bool) (*Options, error) {
 		return nil, err
 	}
 	retOptions.MachineType, err = fromEnvOrError("MACHINE_TYPE")
+	if err != nil {
+		return nil, err
+	}
+	retOptions.ServiceAccount, err = fromEnvOrError("SERVICE_ACCOUNT")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds a new option `SERVICE_ACCOUNT`, which will attach service account with an email specified in an option, and Oauth scope `https://www.googleapis.com/auth/cloud-platform`  into GCP instance for Devpod.

If option is not passed, previous behavior (no service accounts) is preserved.