### PR TITLE
Add startup script option

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -96,6 +96,10 @@ func buildInstance(options *options.Options) (*computepb.Instance, error) {
 					Key:   ptr.Ptr("ssh-keys"),
 					Value: ptr.Ptr("devpod:" + string(publicKey)),
 				},
+				{
+					Key:   ptr.Ptr("startup-script"),
+					Value: ptr.Ptr(options.StartupScript),
+				},
 			},
 		},
 		MachineType: ptr.Ptr(fmt.Sprintf("projects/%s/zones/%s/machineTypes/%s", options.Project, options.Zone, options.MachineType)),

--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -105,6 +105,9 @@ options:
   TAG:
     description: A tag to attach to the instance.
     default: "devpod"
+  STARTUP_SCRIPT:
+    description: A startup script to run on the VM.
+    default: ""
   DISK_SIZE:
     description: The disk size to use (GB).
     default: "40"

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -19,6 +19,7 @@ type Options struct {
 	MachineType    string
 	ServiceAccount string
 	PublicIP       bool
+	StartupScript  string
 }
 
 func FromEnv(withMachine bool) (*Options, error) {
@@ -56,6 +57,10 @@ func FromEnv(withMachine bool) (*Options, error) {
 		return nil, err
 	}
 	retOptions.MachineType, err = fromEnvOrError("MACHINE_TYPE")
+	if err != nil {
+		return nil, err
+	}
+	retOptions.StartupScript, err = fromEnvOrError("STARTUP_SCRIPT")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adding option to provide a startup script. 
The lack of multiline inputs in the devpod UI does make it a bit ackward to use, but being able to manipulate the VM at startup time is important in some situations, like installing GPU drivers. 

Fixes https://github.com/loft-sh/devpod/issues/1429 

I'm not quite sure what the dev workflow is to test changes like this. Is the idea to run build.sh, and then manually manipulate  the yaml to point to local files instead of the github.com hosted ones?